### PR TITLE
Added support for user/pass on Proxies 

### DIFF
--- a/TikTokApi/browser.py
+++ b/TikTokApi/browser.py
@@ -6,7 +6,7 @@ from pyppeteer_stealth import stealth
 
 
 class browser:
-    def __init__(self, url, language='en', proxy=None, find_redirect=False):
+    def __init__(self, url, language='en', proxy=None, proxy_user=None, proxy_pass=None, find_redirect=False):
         self.url = url
         self.language = language
         self.userAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1"
@@ -22,6 +22,9 @@ class browser:
 
         if proxy != None:
             self.args.append("--proxy-server=" + proxy)
+        if proxy_user != None:
+            self.proxy_user = proxy_user
+            self.proxy_pass = proxy_pass
 
         self.options = {
             'args': self.args,
@@ -38,11 +41,17 @@ class browser:
         if find_redirect:
             loop.run_until_complete(self.find_redirect())
         else:
-            loop.run_until_complete(self.start())
+            loop.run_until_complete(self.start(proxy_user=proxy_user, proxy_pass=proxy_pass))
 
-    async def start(self):
+    async def start(self, proxy_user=None, proxy_pass=None):
         self.browser = await pyppeteer.launch(self.options)
         self.page = await self.browser.newPage()
+        
+        if proxy_user != None:
+            await  self.page.authenticate({ 
+                'username': proxy_user, 
+                'password': proxy_pass 
+      });
 
         await stealth(self.page)
 

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -24,7 +24,7 @@ class TikTokApi:
     #
     # Method that retrives data from the api
     #
-    def getData(self, api_url, signature, userAgent, language='en', proxy=None):
+    def getData(self, api_url, signature, userAgent, language='en', proxy=None, proxy_user=None, proxy_pass=None):
         url = api_url + \
             "&_signature=" + signature
 
@@ -44,7 +44,7 @@ class TikTokApi:
                                        'sec-fetch-site': 'same-site',
                                        'path': url.split("tiktok.com")[1],
                                        'accept-language': 'en-US,en;q=0.9'
-                                       }, proxies=self.__format_proxy(proxy))
+                                       }, proxies=self.__format_proxy(proxy, proxy_user, proxy_pass))
         try:
             return r.json()
         except:
@@ -56,7 +56,7 @@ class TikTokApi:
     # Method that retrives data from the api
     #
 
-    def getBytes(self, api_url, signature, userAgent, proxy=None):
+    def getBytes(self, api_url, signature, userAgent, proxy=None, proxy_user=None, proxy_pass=None):
         url = api_url + \
             "&_signature=" + signature
         r = requests.get(url, headers={"method": "GET",
@@ -70,7 +70,7 @@ class TikTokApi:
     # Gets trending Tiktoks
     #
 
-    def trending(self, count=30, language='en', proxy=None):
+    def trending(self, count=30, language='en', proxy=None, proxy_user=None, proxy_pass=None):
         response = []
         maxCount = 99
         maxCursor = 0
@@ -82,9 +82,9 @@ class TikTokApi:
                 realCount = maxCount
             api_url = "https://m.tiktok.com/api/item_list/?count={}&id=1&type=5&secUid=&maxCursor={}&minCursor=0&sourceType=12&appId=1233&region=US&language={}&verifyFp=".format(
                 str(realCount), str(maxCursor), str(language))
-            b = browser(api_url, language=language, proxy=proxy)
+            b = browser(api_url, language=language, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
             res = self.getData(api_url, b.signature,
-                               b.userAgent, language=language, proxy=proxy)
+                               b.userAgent, language=language, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
 
             for t in res['items']:
                 response.append(t)
@@ -101,7 +101,7 @@ class TikTokApi:
     #
     # Gets a specific user's tiktoks
     #
-    def userPosts(self, userID, secUID, count=30, language='en', proxy=None):
+    def userPosts(self, userID, secUID, count=30, language='en', proxy=None, proxy_user=None, proxy_pass=None):
         response = []
         maxCount = 99
         maxCursor = 0
@@ -114,8 +114,8 @@ class TikTokApi:
 
             api_url = "https://m.tiktok.com/api/item_list/?count={}&id={}&type=1&secUid={}&maxCursor={}&minCursor=0&sourceType=8&appId=1233&region=US&language={}&verifyFp=".format(
                 str(realCount), str(userID), str(secUID), str(maxCursor), str(language))
-            b = browser(api_url, proxy=proxy)
-            res = self.getData(api_url, b.signature, b.userAgent, proxy=proxy)
+            b = browser(api_url, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
+            res = self.getData(api_url, b.signature, b.userAgent, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
 
             for t in res['items']:
                 response.append(t)
@@ -133,9 +133,9 @@ class TikTokApi:
     # Gets a specific user's tiktoks by username
     #
 
-    def byUsername(self, username, count=30, proxy=None):
-        data = self.getUserObject(username, proxy=proxy)
-        return self.userPosts(data['id'], data['secUid'], count=count, proxy=proxy)
+    def byUsername(self, username, count=30, proxy=None, proxy_user=None, proxy_pass=None):
+        data = self.getUserObject(username, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
+        return self.userPosts(data['id'], data['secUid'], count=count, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
 
     #
     # Gets tiktoks by music ID
@@ -143,7 +143,7 @@ class TikTokApi:
     # id - the sound ID
     #
 
-    def bySound(self, id, count=30, language='en', proxy=None):
+    def bySound(self, id, count=30, language='en', proxy=None, proxy_user=None, proxy_pass=None):
         response = []
         maxCount = 99
         maxCursor = 0
@@ -156,8 +156,8 @@ class TikTokApi:
 
             api_url = "https://m.tiktok.com/share/item/list?secUid=&id={}&type=4&count={}&minCursor=0&maxCursor={}&shareUid=&lang={}&verifyFp=".format(
                 str(id), str(realCount), str(maxCursor), str(language))
-            b = browser(api_url, proxy=proxy)
-            res = self.getData(api_url, b.signature, b.userAgent, proxy=proxy)
+            b = browser(api_url, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
+            res = self.getData(api_url, b.signature, b.userAgent, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
 
             for t in res['body']['itemListData']:
                 response.append(t)
@@ -174,17 +174,17 @@ class TikTokApi:
     #
     # Gets the music object
     #
-    def getMusicObject(self, id, language='en', proxy=None):
+    def getMusicObject(self, id, language='en', proxy=None, proxy_user=None, proxy_pass=None):
         api_url = "https://m.tiktok.com/api/music/detail/?musicId={}&language={}&verifyFp=".format(
             str(id), language)
-        b = browser(api_url, proxy=proxy)
-        return self.getData(api_url, b.signature, b.userAgent, proxy=proxy)
+        b = browser(api_url, proxy=proxy, proxy_user=proxy_user, proxy_pass = proxy_pass)
+        return self.getData(api_url, b.signature, b.userAgent, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
 
     #
     # Gets tiktoks by hashtag
     #
 
-    def byHashtag(self, hashtag, count=30, language='en', proxy=None):
+    def byHashtag(self, hashtag, count=30, language='en', proxy=None, proxy_user=None, proxy_pass=None):
         id = self.getHashtagObject(hashtag)['challengeInfo']['challenge']['id']
         response = []
         maxCount = 99
@@ -198,8 +198,8 @@ class TikTokApi:
 
             api_url = "https://m.tiktok.com/share/item/list?secUid=&id={}&type=3&count={}&minCursor=0&maxCursor={}&shareUid=&lang={}&verifyFp=".format(
                 str(id), str(realCount), str(maxCursor), language)
-            b = browser(api_url, proxy=proxy)
-            res = self.getData(api_url, b.signature, b.userAgent, proxy=proxy)
+            b = browser(api_url, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
+            res = self.getData(api_url, b.signature, b.userAgent, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
 
             for t in res['body']['itemListData']:
                 response.append(t)
@@ -217,98 +217,98 @@ class TikTokApi:
     # Gets tiktoks by hashtag (for use in byHashtag)
     #
 
-    def getHashtagObject(self, hashtag, language='en', proxy=None):
+    def getHashtagObject(self, hashtag, language='en', proxy=None, proxy_user=None, proxy_pass=None):
         api_url = "https://m.tiktok.com/api/challenge/detail/?verifyFP=&challengeName={}&language={}".format(
             str(hashtag.encode('utf-8'))[2:-1].replace("\\x", "%").upper(), language)
-        b = browser(api_url, proxy=proxy)
-        return self.getData(api_url, b.signature, b.userAgent, proxy=proxy)
+        b = browser(api_url, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
+        return self.getData(api_url, b.signature, b.userAgent, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
 
     #
     # Get a tiktok object with another tiktok's id
     #
-    def getRecommendedTikToksByVideoID(self, id, language='en', proxy=None):
+    def getRecommendedTikToksByVideoID(self, id, language='en', proxy=None, proxy_user=None, proxy_pass=None):
         api_url = "https://m.tiktok.com/share/item/list?secUid=&id={}&type=0&count=24&minCursor=0&maxCursor=0&shareUid=&recType=3&lang={}&verifyFp=".format(
             id, language)
-        b = browser(api_url, proxy=proxy)
-        return self.getData(api_url, b.signature, b.userAgent, proxy=proxy)['body']
+        b = browser(api_url, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
+        return self.getData(api_url, b.signature, b.userAgent, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)['body']
 
     #
     # Gets a tiktok object by ID
     #
-    def getTikTokById(self, id, language='en', proxy=None):
+    def getTikTokById(self, id, language='en', proxy=None, proxy_user=None, proxy_pass=None):
         api_url = "https://m.tiktok.com/api/item/detail/?itemId={}&language={}&verifyFp=".format(
             id, language)
-        b = browser(api_url, proxy=proxy)
-        return self.getData(api_url, b.signature, b.userAgent, proxy=proxy)
+        b = browser(api_url, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
+        return self.getData(api_url, b.signature, b.userAgent, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
 
     #
     # Get a tiktok object by url
     #
-    def getTikTokByUrl(self, url, language='en', proxy=None):
+    def getTikTokByUrl(self, url, language='en', proxy=None, proxy_user=None, proxy_pass=None):
         if "@" in url and "/video/" in url:
             post_id = url.split("/video/")[1]
         else:
             raise Exception(
                 "URL format not supported. Below is an example of a supported url.\nhttps://www.tiktok.com/@therock/video/6829267836783971589")
 
-        return self.getTikTokById(post_id, language=language, proxy=proxy)
+        return self.getTikTokById(post_id, language=language, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
 
     #
     # Discover page, consists challenges (hashtags)
     #
 
-    def discoverHashtags(self, proxy=None):
+    def discoverHashtags(self, proxy=None, proxy_user=None, proxy_pass=None):
         api_url = "https://m.tiktok.com/node/share/discover?noUser=1&userCount=30&scene=0&verifyFp="
         b = browser(api_url, proxy=proxy)
-        return self.getData(api_url, b.signature, b.userAgent, proxy=proxy)['body'][1]['exploreList']
+        return self.getData(api_url, b.signature, b.userAgent, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)['body'][1]['exploreList']
 
     #
     # Discover page, consists of music
     #
 
-    def discoverMusic(self, proxy=None):
+    def discoverMusic(self, proxy=None, proxy_user=None, proxy_pass=None):
         api_url = "https://m.tiktok.com/node/share/discover?noUser=1&userCount=30&scene=0&verifyFp="
         b = browser(api_url, proxy=proxy)
-        return self.getData(api_url, b.signature, b.userAgent, proxy=proxy)['body'][2]['exploreList']
+        return self.getData(api_url, b.signature, b.userAgent, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)['body'][2]['exploreList']
     #
     # Gets a user object for id and secUid
     #
 
-    def getUserObject(self, username, language='en', proxy=None):
-        return self.getUser(username, language, proxy=proxy)['userInfo']['user']
+    def getUserObject(self, username, language='en', proxy=None, proxy_user=None, proxy_pass=None):
+        return self.getUser(username, language, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)['userInfo']['user']
 
     #
     # Gets the full exposed user object
     #
-    def getUser(self, username, language='en', proxy=None):
+    def getUser(self, username, language='en', proxy=None, proxy_user=None, proxy_pass=None):
         api_url = "https://m.tiktok.com/api/user/detail/?uniqueId={}&language={}&verifyFp=".format(
             username, language)
-        b = browser(api_url, proxy=proxy)
-        return self.getData(api_url, b.signature, b.userAgent, proxy=proxy)
+        b = browser(api_url, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
+        return self.getData(api_url, b.signature, b.userAgent, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
 
     #
     # Get Suggested Users for given userID
     #
-    def getSuggestedUsersbyID(self, count=30, userId='6745191554350760966', language='en', proxy=None):
+    def getSuggestedUsersbyID(self, count=30, userId='6745191554350760966', language='en', proxy=None, proxy_user=None, proxy_pass=None):
         api_url = "https://m.tiktok.com/node/share/discover?noUser=0&pageId={}&userId={}&userCount={}&scene=15&verifyFp=".format(
             userId, userId, str(count))
-        b = browser(api_url, proxy=proxy)
+        b = browser(api_url, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
 
         res = []
-        for x in self.getData(api_url, b.signature, b.userAgent, proxy=proxy)['body'][0]['exploreList']:
+        for x in self.getData(api_url, b.signature, b.userAgent, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)['body'][0]['exploreList']:
             res.append(x['cardItem'])
         return res[:count]
 
     #
     # Crawler for Suggested Users
     #
-    def getSuggestedUsersbyIDCrawler(self, count=30, startingId='6745191554350760966', language='en', proxy=None):
+    def getSuggestedUsersbyIDCrawler(self, count=30, startingId='6745191554350760966', language='en', proxy=None, proxy_user=None, proxy_pass=None):
         users = []
         unusedIDS = [startingId]
         while len(users) < count:
             userId = random.choice(unusedIDS)
             newUsers = self.getSuggestedUsersbyID(
-                userId=userId, language=language, proxy=proxy)
+                userId=userId, language=language, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
             unusedIDS.remove(userId)
 
             for user in newUsers:
@@ -321,27 +321,27 @@ class TikTokApi:
     #
     # Get suggested hashtags given userID
     #
-    def getSuggestedHashtagsbyID(self, count=30, userId='6745191554350760966', language='en', proxy=None):
+    def getSuggestedHashtagsbyID(self, count=30, userId='6745191554350760966', language='en', proxy=None, proxy_user=None, proxy_pass=None):
         api_url = "https://m.tiktok.com/node/share/discover?noUser=0&pageId={}&userId={}&userCount={}&scene=15&verifyFp=".format(
             userId, userId, str(count))
         b = browser(api_url, proxy=proxy)
 
         res = []
-        for x in self.getData(api_url, b.signature, b.userAgent, proxy=proxy)['body'][0]['exploreList']:
+        for x in self.getData(api_url, b.signature, b.userAgent, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)['body'][0]['exploreList']:
             res.append(x['cardItem'])
         return res[:count]
 
     #
     # Crawler for Suggested Hashtags
     #
-    def getSuggestedHashtagsbyIDCrawler(self, count=30, startingId='6745191554350760966', language='en', proxy=None):
+    def getSuggestedHashtagsbyIDCrawler(self, count=30, startingId='6745191554350760966', language='en', proxy=None, proxy_user=None, proxy_pass=None):
         hashtags = []
         ids = self.getSuggestedUsersbyIDCrawler(
-            count=count, startingId=startingId, language=language, proxy=proxy)
+            count=count, startingId=startingId, language=language, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
         while len(hashtags) < count:
             userId = random.choice(ids)
             newTags = self.getSuggestedHashtagsbyID(
-                userId=userId['id'], language=language, proxy=proxy)
+                userId=userId['id'], language=language, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
             ids.remove(userId)
 
             for hashtag in newTags:
@@ -353,27 +353,27 @@ class TikTokApi:
     #
     # Get suggested music by given userID
     #
-    def getSuggestedMusicbyID(self, count=30, userId='6745191554350760966', language='en', proxy=None):
+    def getSuggestedMusicbyID(self, count=30, userId='6745191554350760966', language='en', proxy=None, proxy_user=None, proxy_pass=None):
         api_url = "https://m.tiktok.com/node/share/discover?noUser=0&pageId={}&userId={}&userCount={}&scene=15&verifyFp=".format(
             userId, userId, str(count))
-        b = browser(api_url, proxy=proxy)
+        b = browser(api_url, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
 
         res = []
-        for x in self.getData(api_url, b.signature, b.userAgent, proxy=proxy)['body'][0]['exploreList']:
+        for x in self.getData(api_url, b.signature, b.userAgent, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)['body'][0]['exploreList']:
             res.append(x['cardItem'])
         return res[:count]
 
     #
     # Crawler for Suggested Music
     #
-    def getSuggestedMusicIDCrawler(self, count=30, startingId='6745191554350760966', language='en', proxy=None):
+    def getSuggestedMusicIDCrawler(self, count=30, startingId='6745191554350760966', language='en', proxy=None, proxy_user=None, proxy_pass=None):
         musics = []
         ids = self.getSuggestedUsersbyIDCrawler(
-            count=count, startingId=startingId, language=language, proxy=proxy)
+            count=count, startingId=startingId, language=language, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
         while len(musics) < count:
             userId = random.choice(ids)
             newTags = self.getSuggestedMusicbyID(
-                userId=userId['id'], language=language, proxy=proxy)
+                userId=userId['id'], language=language, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
             ids.remove(userId)
 
             for music in newTags:
@@ -386,16 +386,16 @@ class TikTokApi:
     # Downloads video from TikTok using a TikTok object
     #
 
-    def get_Video_By_TikTok(self, data, proxy=None):
+    def get_Video_By_TikTok(self, data, proxy=None, proxy_user=None, proxy_pass=None):
         api_url = data['video']['downloadAddr']
-        return self.get_Video_By_DownloadURL(api_url, proxy=proxy)
+        return self.get_Video_By_DownloadURL(api_url, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
 
     #
     # Downloads video from TikTok using download url in a tiktok object
     #
-    def get_Video_By_DownloadURL(self, download_url, proxy=None):
+    def get_Video_By_DownloadURL(self, download_url, proxy=None, proxy_user=None, proxy_pass=None):
         b = browser(download_url, proxy=proxy)
-        return self.getBytes(download_url, b.signature, b.userAgent, proxy=proxy)
+        return self.getBytes(download_url, b.signature, b.userAgent, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
 
     #
     # Gets the source url of a given url for a tiktok
@@ -426,7 +426,7 @@ class TikTokApi:
     #
     # No Water Mark
     #
-    def get_Video_No_Watermark(self, video_url, return_bytes=1, proxy=None):
+    def get_Video_No_Watermark(self, video_url, return_bytes=1, proxy=None, proxy_user=None, proxy_pass=None):
         r = requests.get(video_url, headers={"method": "GET",
                                              "accept-encoding": "utf-8",
                                              "user-agent": self.userAgent
@@ -459,7 +459,7 @@ class TikTokApi:
 
             cleanVideo = "https://api2.musical.ly/aweme/v1/playwm/?video_id=" + key
 
-            b = browser(cleanVideo, find_redirect=True, proxy=proxy)
+            b = browser(cleanVideo, find_redirect=True, proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)
 
             if return_bytes == 0:
                 return b.redirect_url
@@ -475,11 +475,19 @@ class TikTokApi:
     #
     # Formats the proxy object
     #
-    def __format_proxy(self, proxy):
-        if proxy != None:
+    def __format_proxy(self, proxy, proxy_user=None, proxy_pass=None):
+        if proxy_user != None:
+            return {
+                'http': 'http://' + proxy_user + ':' + proxy_pass + '@' + proxy,
+                'https': 'http://' + proxy_user + ':' + proxy_pass + '@' + proxy
+            }
+        elif proxy != None:
             return {
                 'http': proxy,
                 'https': proxy
             }
         else:
             return None
+        
+
+

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -28,7 +28,8 @@ class TikTokApi:
         url = api_url + \
             "&_signature=" + signature
 
-        r = requests.get(url, headers={"method": "GET",
+        r = requests.
+        url, headers={"method": "GET",
                                        "accept-encoding": "gzip, deflate, br",
                                        "referrer": self.referrer + language,
                                        "user-agent": userAgent,
@@ -63,7 +64,7 @@ class TikTokApi:
                                        "accept-encoding": "gzip, deflate, br",
                                        "referrer": self.referrer,
                                        "user-agent": userAgent,
-                                       }, proxies=self.__format_proxy(proxy))
+                                       }, proxies=self.__format_proxy(proxy, proxy_user, proxy_pass))
         return r.content
 
     #
@@ -442,7 +443,7 @@ class TikTokApi:
                                                   'Range': 'bytes=0-200000',
                                                   'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
                                                   "user-agent": self.userAgent
-                                                  }, proxies=self.__format_proxy(proxy))
+                                                  }, proxies=self.__format_proxy(proxy, proxy_user, proxy_pass))
 
             tmp = r.text.split("vid:")
             if len(tmp) > 1:
@@ -465,7 +466,7 @@ class TikTokApi:
                 return b.redirect_url
             else:
                 r = requests.get(
-                    b.redirect_url, proxies=self.__format_proxy(proxy))
+                    b.redirect_url, proxies=self.__format_proxy(proxy, proxy_user, proxy_pass))
                 return r.content
 
     #


### PR DESCRIPTION
Pyppeteer doesn't play nice with the http://user:pass@ip:port format of proxy that Requests likes - so I've added  a couple of additional arguments that can be passed in: proxy_user & proxy_pass.

Example usage:

proxy = '90.200.12.124:5432'
proxy_user = 'user'
proxy_pass = 'pass'

api.getUserObject(username, language='en', proxy=proxy, proxy_user=proxy_user, proxy_pass=proxy_pass)

The code can be improved to take the proxy input as a request compatible string (user:pass@ip:port) and then have the internal function slice the text up but this version seems workable and solves the immediate need.
