### PR TITLE
Add Paging for hashtags

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,49 @@ video_url - the url of the video you wish to download
 
 return_bytes - if you want to return bytes or a url
 
+##### The getUserPager method
+```
+api.getUserPager(username, page_size=30, before=0, after=0)
+```
+This endpoint returns a generator, which emits pages of tiktok records posted by the user specified by `username`.
+The size of the pages can be specified with `page_size`.  The generator will request the next `page` of results
+lazily, and terminate once the TikTok api indicates that the feed has been exhausted.
+
+`before` and `after` are cursor parameters that accept millisecond-precision UNIX timestamps. Note that the generator
+does use these values internally to manage paging, but if you pass them in here that will only set their 'starting
+points.  For `after`, that means setting a hard limit on how far back in the user's feed to go, bur `before` sets the
+starting point for pagination.  If they are not passed (or 0 is passed for them), then the pager will be able to
+traverse the user's entire feed.
+
+One more note: The pages of results are often one or two records short of the full `page_size` specified, even if
+there are more results.  This doesn't mean that tiktoks are being missed, just that TikTok didn't deign to fill the
+page completely.
+
+username - TikTok username for the user from which to request tiktoks
+
+page_size - integer specifying the maximum number of tiktoks to return in a page (default 30)
+
+after - millisecond-precision UNIX timestamp. only tiktoks posted after that time will be retrieved. (default 0)
+
+before - millisecond-precision UNIX timestamp.  only tiktoks posted before that time will be retrieved. (default infinity)
+
+##### The getHashtagPager method
+```
+api.getHashtagPager(hashtag, page_size=30)
+```
+This endpoint returns a generator, which emits pages of tiktok records posted under a given hashtag. The size
+of the pages can be specified with `page_size`.  The generator will request the next `page` of results lazily, and
+terminate once the TikTok api indicates that the feed has been exhausted.
+
+One more note: The pages of results are often one or two records short of the full `page_size` specified, even if
+there are more results.  This doesn't mean that tiktoks are being missed, just that TikTok didn't deign to fill the
+page completely.
+
+hashtag - string representation of the hashtag in question (without the '#' prefix)
+
+page_size - integer specifying the maximum number of tiktoks to return in a page (default 30)
+
+
 ## Built With
 
 * [Python 3.7](https://www.python.org/) - The web framework used

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -584,12 +584,13 @@ class TikTokApi:
 
         return response[:count]
 
-    def getHashtagPager(self, hashtag, page_size=30, before=0, after=0, proxy=None, language='en', region='US'):
+    def getHashtagPager(self, hashtag, page_size=30, max_pages=0, proxy=None, language='en', region='US'):
         id = self.getHashtagObject(hashtag)['challengeInfo']['challenge']['id']
 
+        before = 0
         while True:
             resp = self.hashtagPage(
-                id, page_size=page_size, before=before, after=after, proxy=proxy, language=language, region=region
+                id, page_size=page_size, before=before, proxy=proxy, language=language, region=region
             )
 
             has_more = resp['body']['hasMore']
@@ -603,18 +604,22 @@ class TikTokApi:
             before = resp['body']['maxCursor']
 
             yield page
+            max_pages -= 1
+
+            if max_pages == 0:
+                has_more = False
 
             if not has_more:
                 return  # all done
 
-    def hashtagPage(self, id, page_size=30, before=0, after=0, language='en', region='US', proxy=None):
+    def hashtagPage(self, id, page_size=30, before=0, language='en', region='US', proxy=None):
         query = {
             'count': page_size,
             'id': id,
             'type': 3,
             'secUid': '',
             'minCursor': before,
-            'maxCursor': after,
+            'maxCursor': 0,
             'shareUid': '',
             'recType': '',
             'region': region,

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -618,6 +618,8 @@ class TikTokApi:
             yield page
             max_pages -= 1
 
+            # comparing directly to zero so that the default max_pages (0) will never trip this
+            # therefore paging to the end.
             if max_pages == 0:
                 has_more = False
 

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -85,6 +85,7 @@ class TikTokApi:
             "user-agent": b.userAgent,
             'cookie': 'tt_webid_v2=' + b.did
         }, proxies=self.__format_proxy(proxy))
+
         try:
             return response.json()
         except Exception as exc:
@@ -585,6 +586,17 @@ class TikTokApi:
         return response[:count]
 
     def getHashtagPager(self, hashtag, page_size=30, max_pages=0, proxy=None, language='en', region='US'):
+        """Returns a generator to page through results for a hashtag
+
+        :param hashtag: The hashtag to search by
+        :param page_size: Maximum # of results to be returned per page (may be fewer)
+        :param max_pages: Maximum pages to go through.  default will page until tiktok stops it.
+        :param language: The 2 letter code of the language to return.
+                         Note: Doesn't seem to have an affect.
+        :param region: The 2 letter region code.
+                       Note: Doesn't seem to have an affect.
+        :param proxy: The IP address of a proxy to make requests from.
+        """
         id = self.getHashtagObject(hashtag)['challengeInfo']['challenge']['id']
 
         before = 0
@@ -613,6 +625,17 @@ class TikTokApi:
                 return  # all done
 
     def hashtagPage(self, id, page_size=30, before=0, language='en', region='US', proxy=None):
+        """Request a page of hashtag results from tiktok
+
+        :param id: id of the hashtag ('challenge') to search
+        :param page_size: Maximum # of results to be returned per page (may be fewer)
+        :param before: pagination cursor value.  Used by the paging generator.
+        :param language: The 2 letter code of the language to return.
+                         Note: Doesn't seem to have an affect.
+        :param region: The 2 letter region code.
+                       Note: Doesn't seem to have an affect.
+        :param proxy: The IP address of a proxy to make requests from.
+        """
         query = {
             'count': page_size,
             'id': id,

--- a/examples/demoHashtagPager.py
+++ b/examples/demoHashtagPager.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+from TikTokApi import TikTokApi
+
+api = TikTokApi(debug=True)
+
+def printPage(page):
+    """Just prints out each post with timestamp and description"""
+    for p in page:
+        post = p['itemInfos']
+        print("{}: {}".format(datetime.fromtimestamp(int(post['createTime'])), post['text']))
+
+count = 50
+hashtag = 'funny'
+
+pager = api.getHashtagPager(hashtag, page_size=count)
+
+total = 0
+oldest = None
+for posts in pager:
+    for post in posts:
+        created_at = int(post['itemInfos']['createTime'])
+
+        if oldest is None:
+            oldest = created_at
+
+        if created_at < oldest:
+            oldest = created_at
+
+    printPage(posts)
+    total += len(posts)
+
+if oldest is None:
+    print('Nothing found')
+else:
+    print(f"found {total} posts for #{hashtag}. Oldest is from {datetime.fromtimestamp(oldest)}")

--- a/examples/demoHashtagPager.py
+++ b/examples/demoHashtagPager.py
@@ -3,11 +3,13 @@ from TikTokApi import TikTokApi
 
 api = TikTokApi(debug=True)
 
+
 def printPage(page):
     """Just prints out each post with timestamp and description"""
     for p in page:
         post = p['itemInfos']
         print("{}: {}".format(datetime.fromtimestamp(int(post['createTime'])), post['text']))
+
 
 count = 50
 hashtag = 'funny'
@@ -26,7 +28,7 @@ for posts in pager:
         if created_at < oldest:
             oldest = created_at
 
-    printPage(posts)
+    # printPage(posts)
     total += len(posts)
 
 if oldest is None:

--- a/tests/test_hashtagPager.py
+++ b/tests/test_hashtagPager.py
@@ -1,0 +1,28 @@
+from TikTokApi import TikTokApi
+
+
+class TestHashtagPager:
+    """Test the pager returned by getHashtagPager"""
+    def test_page_size(self):
+        """Pages should be pretty close to the specified size"""
+        api = TikTokApi()
+
+        pager = api.getHashtagPager('regal', page_size=5)
+
+        page = pager.__next__()
+        assert abs(len(page)-5) <= 2
+
+        page = pager.__next__()
+        assert abs(len(page)-5) <= 2
+
+    def test_max_pages(self):
+        """Should have x pages only"""
+        api = TikTokApi()
+
+        pager = api.getHashtagPager('regal', max_pages=4)
+
+        pages = 0
+        for page in pager:
+            pages += 1
+
+        assert pages == 4


### PR DESCRIPTION
This is very similar to the user pager, but tiktok handles hashtags a little differently. They don't come in a predictable chronological order like a user feed does, despite using the `maxCursor` timestamp parameter to indicate the next page.  So this endpoint doesn't accept `before` or `after` parameters.

It does accept a `max_pages` parameter though, which will stop paging after x pages are retrieved.

Includes tests, example script, and README documentation.