### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/playwright:focal
+
+RUN apt-get update && apt-get install -y python3-pip
+
+RUN pip3 install TikTokApi


### PR DESCRIPTION
can be used to run scripts from example's directory without installing playwright/python/TikTokApi locally
```$ docker build .```
```$ docker run -v $PWD:/script <built-image-id> python3 /script/download_liked.py```
