### PR TITLE
x-secsdk-csrf-token is now 92 chars long

### DIFF
--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -257,7 +257,7 @@ class TikTokApi:
                 "user-agent": userAgent,
                 "x-secsdk-csrf-token": "".join(
                     random.choice(string.ascii_uppercase + string.ascii_lowercase)
-                    for i in range(53))
+                    for i in range(92))
             },
             cookies=self.get_cookies(**kwargs),
             proxies=self.__format_proxy(proxy),


### PR DESCRIPTION
After some tries, it seems that x-secsdk-csrf-token in headers moves from 53 chars long to 92 chars