### PR TITLE
Outdated User Agent

### DIFF
--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -870,7 +870,7 @@ class TikTokApi:
                 "Accept-Encoding": "gzip, deflate",
                 "Connection": "keep-alive",
                 "Host": "www.tiktok.com",
-                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.111 Safari/537.36",
+                "User-Agent": self.userAgent,
             },
             proxies=self.__format_proxy(kwargs.get("proxy", None)),
             cookies=self.get_cookies(**kwargs),


### PR DESCRIPTION
Update User Agent. Let me know if this is the wrong course of action, but when I switched to the new user agent on my local computer I stopped getting captcha blocked by TikTok.

- Isaac