### PR TITLE
V4.0.4 - Fix Subpackage Finding

### DIFF
--- a/TikTokApi/browser_utilities/browser_interface.py
+++ b/TikTokApi/browser_utilities/browser_interface.py
@@ -10,7 +10,7 @@ class BrowserInterface(abc.ABC):
 
     # Returns verify_fp, device_id, signature, tt_params
     @abc.abstractmethod
-    def sign_url(self, calc_tt_params=False, **kwargs) -> tuple[str, str, str, str]:
+    def sign_url(self, calc_tt_params=False, **kwargs):
         pass
 
     @abc.abstractmethod

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="TikTokApi",
-    packages=["TikTokApi"],
-    version="4.0.3",
+    packages=setuptools.find_packages(),
+    version="4.0.4",
     license="MIT",
     description="The Unofficial TikTok API Wrapper in Python 3.",
     author="David Teather",


### PR DESCRIPTION
V4.0.3 is messed up because `python setup.py install` didn't find a required submodule of the package.