### PR TITLE
Removed Host and Authority from the requests to prefent the 403 error…

### DIFF
--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -12,7 +12,6 @@ from playwright.sync_api import sync_playwright
 from .exceptions import *
 from .utilities import update_messager
 
-
 os.environ["no_proxy"] = "127.0.0.1,localhost"
 
 BASE_URL = "https://m.tiktok.com/"
@@ -298,8 +297,8 @@ class TikTokApi:
         try:
             json = r.json()
             if (
-                json.get("type") == "verify"
-                or json.get("verifyConfig", {}).get("type", "") == "verify"
+                    json.get("type") == "verify"
+                    or json.get("verifyConfig", {}).get("type", "") == "verify"
             ):
                 logging.error(
                     "Tiktok wants to display a catcha. Response is:\n" + r.text
@@ -673,16 +672,16 @@ class TikTokApi:
         kwargs["custom_device_id"] = device_id
 
         api_url = (
-            BASE_URL + "api/post/item_list/?{}&count={}&id={}&type=1&secUid={}"
-            "&cursor={}&sourceType=8&appId=1233&region={}&language={}".format(
-                self.__add_url_params__(),
-                page_size,
-                str(userID),
-                str(secUID),
-                cursor,
-                region,
-                language,
-            )
+                BASE_URL + "api/post/item_list/?{}&count={}&id={}&type=1&secUid={}"
+                           "&cursor={}&sourceType=8&appId=1233&region={}&language={}".format(
+            self.__add_url_params__(),
+            page_size,
+            str(userID),
+            str(secUID),
+            cursor,
+            region,
+            language,
+        )
         )
 
         return self.get_data(url=api_url, send_tt_params=True, **kwargs)
@@ -946,10 +945,8 @@ class TikTokApi:
             "https://www.tiktok.com/music/-{}".format(id),
             headers={
                 "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
-                "authority": "www.tiktok.com",
                 "Accept-Encoding": "gzip, deflate",
                 "Connection": "keep-alive",
-                "Host": "www.tiktok.com",
                 "User-Agent": self.userAgent,
             },
             proxies=self.__format_proxy(kwargs.get("proxy", None)),
@@ -1197,11 +1194,9 @@ class TikTokApi:
             url,
             headers={
                 "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
-                "authority": "www.tiktok.com",
                 "path": url.split("tiktok.com")[1],
                 "Accept-Encoding": "gzip, deflate",
                 "Connection": "keep-alive",
-                "Host": "www.tiktok.com",
                 "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.111 Safari/537.36",
             },
             proxies=self.__format_proxy(kwargs.get("proxy", None)),
@@ -1292,11 +1287,9 @@ class TikTokApi:
             "https://tiktok.com/@{}?lang=en".format(quote(username)),
             headers={
                 "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
-                "authority": "www.tiktok.com",
                 "path": "/@{}".format(quote(username)),
                 "Accept-Encoding": "gzip, deflate",
                 "Connection": "keep-alive",
-                "Host": "www.tiktok.com",
                 "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.111 Safari/537.36",
             },
             proxies=self.__format_proxy(kwargs.get("proxy", None)),
@@ -1325,7 +1318,7 @@ class TikTokApi:
         return user
 
     def get_suggested_users_by_id(
-        self, userId="6745191554350760966", count=30, **kwargs
+            self, userId="6745191554350760966", count=30, **kwargs
     ) -> list:
         """Returns suggested users given a different TikTok user.
 
@@ -1358,7 +1351,7 @@ class TikTokApi:
         return res[:count]
 
     def get_suggested_users_by_id_crawler(
-        self, count=30, startingId="6745191554350760966", **kwargs
+            self, count=30, startingId="6745191554350760966", **kwargs
     ) -> list:
         """Crawls for listing of all user objects it can find.
 
@@ -1393,7 +1386,7 @@ class TikTokApi:
         return users[:count]
 
     def get_suggested_hashtags_by_id(
-        self, count=30, userId="6745191554350760966", **kwargs
+            self, count=30, userId="6745191554350760966", **kwargs
     ) -> list:
         """Returns suggested hashtags given a TikTok user.
 
@@ -1424,7 +1417,7 @@ class TikTokApi:
         return res[:count]
 
     def get_suggested_hashtags_by_id_crawler(
-        self, count=30, startingId="6745191554350760966", **kwargs
+            self, count=30, startingId="6745191554350760966", **kwargs
     ) -> list:
         """Crawls for as many hashtags as it can find.
 
@@ -1457,7 +1450,7 @@ class TikTokApi:
         return hashtags[:count]
 
     def get_suggested_music_by_id(
-        self, count=30, userId="6745191554350760966", **kwargs
+            self, count=30, userId="6745191554350760966", **kwargs
     ) -> list:
         """Returns suggested music given a TikTok user.
 
@@ -1493,7 +1486,7 @@ class TikTokApi:
         return res[:count]
 
     def get_suggested_music_id_crawler(
-        self, count=30, startingId="6745191554350760966", **kwargs
+            self, count=30, startingId="6745191554350760966", **kwargs
     ) -> list:
         """Crawls for hashtags.
 
@@ -1621,10 +1614,8 @@ class TikTokApi:
             "https://www.tiktok.com/music/-{}".format(id),
             headers={
                 "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
-                "authority": "www.tiktok.com",
                 "Accept-Encoding": "gzip, deflate",
                 "Connection": "keep-alive",
-                "Host": "www.tiktok.com",
                 "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.111 Safari/537.36",
             },
             proxies=self.__format_proxy(kwargs.get("proxy", None)),
@@ -1650,11 +1641,9 @@ class TikTokApi:
             "https://tiktok.com/@{}?lang=en".format(quote(username)),
             headers={
                 "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
-                "authority": "www.tiktok.com",
                 "path": "/@{}".format(quote(username)),
                 "Accept-Encoding": "gzip, deflate",
                 "Connection": "keep-alive",
-                "Host": "www.tiktok.com",
                 "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.111 Safari/537.36",
             },
             proxies=self.__format_proxy(


### PR DESCRIPTION
This pull request fixes the error in issue #751 and #750 by removing the host headers from the requests done with the requests lib.

The error fixed in this pull request:
```
ERROR:root:Tiktok response: 
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
<HTML><HEAD><META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=iso-8859-1">
<TITLE>ERROR: The request could not be satisfied</TITLE>
</HEAD><BODY>
<H1>403 ERROR</H1>
<H2>The request could not be satisfied.</H2>
<HR noshade size="1px">
Bad request.
We can't connect to the server for this app or website at this time. There might be too much traffic or a configuration error. Try again later, or contact the app or website owner.
<BR clear="all">
If you provide content to customers through CloudFront, you can find steps to troubleshoot and help prevent this error by reviewing the CloudFront documentation.
<BR clear="all">
<HR noshade size="1px">
<PRE>
Generated by cloudfront (CloudFront)
Request ID: IeGDfwk6_DQAbAm_pK1GAI1hrszMdKzJIjv0BbfsneGU8p59Gcnv4w==
</PRE>
<ADDRESS>
</ADDRESS>
</BODY></HTML>
```
