### PR TITLE
Fix by_trending (via ttwid)

### DIFF
--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -352,6 +352,7 @@ class TikTokApi:
                     for i in range(16)
                 ),
                 "s_v_web_id": verifyFp,
+                "ttwid": kwargs.get("ttwid")
             }
         else:
             return {
@@ -362,6 +363,7 @@ class TikTokApi:
                     random.choice(string.ascii_uppercase + string.ascii_lowercase)
                     for i in range(16)
                 ),
+                "ttwid": kwargs.get("ttwid")
             }
 
     def get_bytes(self, **kwargs) -> bytes:
@@ -423,7 +425,14 @@ class TikTokApi:
             device_id,
         ) = self.__process_kwargs__(kwargs)
         kwargs["custom_device_id"] = device_id
-
+        
+        spawn = requests.head(
+            "https://www.tiktok.com",
+            proxies=self.__format_proxy(proxy),
+            **self.requests_extra_kwargs
+        )
+        ttwid = spawn.cookies["ttwid"]
+        
         response = []
         first = True
 
@@ -446,7 +455,7 @@ class TikTokApi:
             api_url = "{}api/recommend/item_list/?{}&{}".format(
                 BASE_URL, self.__add_url_params__(), urlencode(query)
             )
-            res = self.get_data(url=api_url, **kwargs)
+            res = self.get_data(url=api_url, ttwid=ttwid, **kwargs)
             for t in res.get("itemList", []):
                 response.append(t)
 


### PR DESCRIPTION
After testing on my own, ttwid is the cookie responsible for by_trending. When included, calls to the trending page are successful. When omitted, they fail.

I have not been able to figure out a way to generate ttwid programatically, however, it is automatically created when visiting www.tiktok.com and even works *without* any parameters.

This code makes a head request to tiktok.com, fetches the ttwid cookie and then supplies it later.
With this, I was able to get trending easily, like previously.