### PR TITLE
Change the exit condition in the `user_liked` method

### DIFF
--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -847,7 +847,7 @@ class TikTokApi:
                 res["itemList"]
             except Exception:
                 logging.error("User's likes are most likely private")
-                return []
+                return response
 
             for t in res.get("itemList", []):
                 response.append(t)

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -852,7 +852,7 @@ class TikTokApi:
             for t in res.get("itemList", []):
                 response.append(t)
 
-            if not res.get("hasMore", False) and not first:
+            if not res.get("hasMore", False) or not first:
                 logging.info("TikTok isn't sending more TikToks beyond this point.")
                 return response
 

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -852,7 +852,7 @@ class TikTokApi:
             for t in res.get("itemList", []):
                 response.append(t)
 
-            if not res.get("hasMore", False) or not first:
+            if not res.get("hasMore", False) and not first:
                 logging.info("TikTok isn't sending more TikToks beyond this point.")
                 return response
 


### PR DESCRIPTION
Hi folks 👋 

I met a problem when I try to fetch user liked videos by using `user_liked` method. 
If user has less liked videos than a `count` parameter, then method would always return `[]`
and log `User's likes are most likely private`. 

I've changed the exit condition to address this issue. 

I've also updated the return statement in case of no videos in response.
Before the PR, the method would return empty list even if any subsequent request after the first one fails. 
After the change the method will return everything it had pulled in previous requests.