### PR TITLE
fixed issue for counts over 30

### DIFF
--- a/TikTokApi/api/user.py
+++ b/TikTokApi/api/user.py
@@ -155,8 +155,8 @@ class User:
             res = User.parent.get_data(path, send_tt_params=True, **kwargs)
 
             videos = res.get("itemList", [])
-            amount_yielded += len(videos)
             for video in videos:
+                amount_yielded += 1
                 yield self.parent.video(data=video)
 
             if not res.get("hasMore", False) and not first:
@@ -218,7 +218,6 @@ class User:
                 return
 
             videos = res.get("itemList", [])
-            amount_yielded += len(videos)
             for video in videos:
                 amount_yielded += 1
                 yield self.parent.video(data=video)


### PR DESCRIPTION
in /TikTokApi/api/user.py: Removed line 158 because 159 is more efficient. (Doesn't have to calculate the length of the videos list) and removed line 221 because the line 223/222 is more efficient (and it was redundant)