### PR TITLE
Updated Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ FROM mcr.microsoft.com/playwright:focal
 RUN apt-get update && apt-get install -y python3-pip
 COPY . .
 RUN pip3 install TikTokApi
-RUN python -m playwright install
+RUN python3 -m playwright install


### PR DESCRIPTION
The mcr.microsoft.com/playwright:focal image does not have a `python` binary. Only the default `python3`. The TikTokApi Dockerfile fails to build without this change.