### PR TITLE
Fix the documentation hyperlink rendering

### DIFF
--- a/docs/TikTokApi.html
+++ b/docs/TikTokApi.html
@@ -148,7 +148,7 @@ TikTokApi    </h1>
 
 <h2 id="documentation">Documentation</h2>
 
-<p>You can find the full documentation <a href="https://davidteather.github.io/TikTok-Api/docs/<a href="#html">TikTokApi.html</a>">here</a>, the <a href="https://davidteather.github.io/TikTok-Api/docs/TikTokApi/tiktok.html">TikTokApi Class</a> is where you'll probably spend most of your time.</p>
+<p>You can find the full documentation <a href="https://davidteather.github.io/TikTok-Api/docs/">here</a>, the <a href="https://davidteather.github.io/TikTok-Api/docs/TikTokApi/tiktok.html">TikTokApi Class</a> is where you'll probably spend most of your time.</p>
 
 <h2 id="getting-started">Getting Started</h2>
 


### PR DESCRIPTION
Updating the html documentation to properly render a little typo I spotted:
![image](https://user-images.githubusercontent.com/51441497/187069909-1f39720a-cc3e-40c4-ad8d-f8bd38ce0b4e.png)
