### PR TITLE
Correctly filling in EmptyResponseException constructor parameters

### DIFF
--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -426,7 +426,7 @@ class TikTokApi:
                 raise Exception("TikTokApi.run_fetch_script returned None")
 
             if result == "":
-                raise EmptyResponseException()
+                raise EmptyResponseException(result, "TikTok returned an empty response")
 
             try:
                 data = json.loads(result)


### PR DESCRIPTION
Very small PR to correctly provide the EmptyResponseException constructor params so that it can correctly throw