### PR TITLE
Made author field optional

### DIFF
--- a/TikTokApi/api/video.py
+++ b/TikTokApi/api/video.py
@@ -218,7 +218,7 @@ class Video:
         self.create_time = datetime.fromtimestamp(timestamp)
         self.stats = data["stats"]
 
-        author = data["author"]
+        author = data.get("author")
         if isinstance(author, str):
             self.author = self.parent.user(username=author)
         else:


### PR DESCRIPTION
Fixed issue where error is raised for some videos that are missing the "author" field.

See these issues: 
- https://github.com/davidteather/TikTok-Api/issues/1057#issue-1876459722
- https://github.com/bellingcat/tiktok-hashtag-analysis/issues/21#issuecomment-1847452682