### PR TITLE
Fix trending count

### DIFF
--- a/TikTokApi/api/trending.py
+++ b/TikTokApi/api/trending.py
@@ -37,7 +37,7 @@ class Trending:
         while found < count:
             params = {
                 "from_page": "fyp",
-                "count": 30,
+                "count": count,
             }
 
             resp = await Trending.parent.make_request(


### PR DESCRIPTION
The existing implementation always returns 30 videos. This fixes that issue to perform as suggested