### PR TITLE
Fix count parameter for hashtag, user, and trending classes

### DIFF
--- a/TikTokApi/api/hashtag.py
+++ b/TikTokApi/api/hashtag.py
@@ -111,7 +111,7 @@ class Hashtag:
         while found < count:
             params = {
                 "challengeID": self.id,
-                "count": 30,
+                "count": count,
                 "cursor": cursor,
             }
 

--- a/TikTokApi/api/trending.py
+++ b/TikTokApi/api/trending.py
@@ -37,7 +37,7 @@ class Trending:
         while found < count:
             params = {
                 "from_page": "fyp",
-                "count": 30,
+                "count": count,
             }
 
             resp = await Trending.parent.make_request(

--- a/TikTokApi/api/user.py
+++ b/TikTokApi/api/user.py
@@ -115,7 +115,7 @@ class User:
         while found < count:
             params = {
                 "secUid": self.sec_uid,
-                "count": 35,
+                "count": count,
                 "cursor": cursor,
             }
 


### PR DESCRIPTION
There's no issue that pertains to this fix so I'll briefly describe it here. When downloading videos through the hashtag, user, and trending classes by calling the video function, it does not use the count parameter to limit the number of video downloads. For example, given this code snippet:

```
async def foo():
    async with TikTokApi() as api:
        await api.create_sessions(ms_tokens=[ms_token], num_sessions=1, sleep_after=3, headless=False)
        async for video in api.trending.videos(count=5):
            print(video.id)

asyncio.run(foo())
```

we would expect 5 ids to be printed. However, since the count values are hard coded in the function, the input count=5 gets overwritten. 