### PR TITLE
New safe character for param encoding

### DIFF
--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -413,7 +413,7 @@ class TikTokApi:
                     )
                 params["msToken"] = ms_token
 
-        encoded_params = f"{url}?{urlencode(params, quote_via=quote)}"
+        encoded_params = f"{url}?{urlencode(params, safe='=', quote_via=quote)}"
         signed_url = await self.sign_url(encoded_params, session_index=i)
 
         retry_count = 0


### PR DESCRIPTION
TikTok frontend seems to have changed their URL param encoding method. Adding the '=' character as safe (used in some security params) seems to results in less empty response errors.