### PR TITLE
Fixed hashtag search pagination

### DIFF
--- a/TikTokApi/api/hashtag.py
+++ b/TikTokApi/api/hashtag.py
@@ -111,7 +111,7 @@ class Hashtag:
         while found < count:
             params = {
                 "challengeID": self.id,
-                "count": count,
+                "count": 35,
                 "cursor": cursor,
             }
 


### PR DESCRIPTION
TikTok appears to have limited the number of posts that can be returned for a single hashtag search to 35 (e.g. https://github.com/bellingcat/tiktok-hashtag-analysis/issues/28).

Similar to how the `User.liked` method works, I set the batch size to 35 videos per request.