### PR TITLE
Add 'executable_path' field to the 'api.create_sessions()' method

### DIFF
--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -212,6 +212,7 @@ class TikTokApi:
         override_browser_args: list[dict] = None,
         cookies: list[dict] = None,
         suppress_resource_load_types: list[str] = None,
+        executable_path: str = None
     ):
         """
         Create sessions for use within the TikTokApi class.
@@ -243,7 +244,10 @@ class TikTokApi:
             override_browser_args = ["--headless=new"]
             headless = False  # managed by the arg
         self.browser = await self.playwright.chromium.launch(
-            headless=headless, args=override_browser_args, proxy=random_choice(proxies)
+            headless=headless,
+            args=override_browser_args,
+            proxy=random_choice(proxies),
+            executable_path=executable_path
         )
 
         await asyncio.gather(


### PR DESCRIPTION
**Adding `executable_path` can solve the issue:**
`EmptyResponseException: None -> TikTok returned an empty response`
https://github.com/davidteather/TikTok-Api/issues/1090

**The example on how it works is in google colab:**
https://colab.research.google.com/drive/14FV3Ja3rmrubQ1FVLNhByTz1n_MPPlKA#scrollTo=h9tG2EQM_Ekd

**Edited:** Forgot to mention that to actually solve the issue you should install an older version of Google Chrome and specify its executable path when calling the `create_sessions` method. 


Version | Result
-- | --
115.0.5790.170 | OK
121.0.6167.57 | NG

(this solution and the table were provided by the author of the https://github.com/davidteather/TikTok-Api/issues/1090#issuecomment-1915841853) 