### PR TITLE
Added support for statsV2

### DIFF
--- a/TikTokApi/api/video.py
+++ b/TikTokApi/api/video.py
@@ -216,7 +216,7 @@ class Video:
                 pass
 
         self.create_time = datetime.fromtimestamp(timestamp)
-        self.stats = data["stats"]
+        self.stats = data.get('statsV2') or data.get('stats')
 
         author = data.get("author")
         if isinstance(author, str):


### PR DESCRIPTION
There is now a statsV2 object that appears to be gradually replacing the original stats object. 
This patch avoids crashes due to statsV2-only users, and gives priority to statsV2 over stats when both are present.

```
{
"stats": {"collectCount": 2787, "commentCount": 16000, "diggCount": 22600, "playCount": 1800000, "shareCount": 259}
}
```
```
{
"statsV2": {"collectCount": "2787", "commentCount": "15955", "diggCount": "22609", "playCount": "1776621", "shareCount": "259"}
}
```