### PR TITLE
fixed error where functions don't respect "count" argument

### DIFF
--- a/TikTokApi/api/comment.py
+++ b/TikTokApi/api/comment.py
@@ -56,7 +56,7 @@ class Comment:
 
         while found < count:
             params = {
-                "count": 20,
+                "count": count,
                 "cursor": cursor,
                 "item_id": self.author.user_id,
                 "comment_id": self.id,

--- a/TikTokApi/api/hashtag.py
+++ b/TikTokApi/api/hashtag.py
@@ -111,7 +111,7 @@ class Hashtag:
         while found < count:
             params = {
                 "challengeID": self.id,
-                "count": 35,
+                "count": count,
                 "cursor": cursor,
             }
 

--- a/TikTokApi/api/sound.py
+++ b/TikTokApi/api/sound.py
@@ -114,7 +114,7 @@ class Sound:
         while found < count:
             params = {
                 "musicID": id,
-                "count": 30,
+                "count": count,
                 "cursor": cursor,
             }
 

--- a/TikTokApi/api/user.py
+++ b/TikTokApi/api/user.py
@@ -111,7 +111,7 @@ class User:
         while found < count:
           params = {
               "secUid": sec_uid,
-              "count": 20,
+              "count": count,
               "cursor": cursor,
           }
 
@@ -163,7 +163,7 @@ class User:
         while found < count:
             params = {
                 "secUid": self.sec_uid,
-                "count": 35,
+                "count": count,
                 "cursor": cursor,
             }
 
@@ -218,7 +218,7 @@ class User:
         while found < count:
             params = {
                 "secUid": self.sec_uid,
-                "count": 35,
+                "count": count,
                 "cursor": cursor,
             }
 

--- a/TikTokApi/api/video.py
+++ b/TikTokApi/api/video.py
@@ -244,7 +244,7 @@ class Video:
         while found < count:
             params = {
                 "aweme_id": self.id,
-                "count": 20,
+                "count": count,
                 "cursor": cursor,
             }
 
@@ -293,7 +293,7 @@ class Video:
         while found < count:
             params = {
                 "itemID": self.id,
-                "count": 16,
+                "count": count,
             }
 
             resp = await self.parent.make_request(


### PR DESCRIPTION
when using `TikTokApi().sound.videos(count=N)`, the library doesn't respect only grabbing `N` videos, and instead always grabs 30. 

this is because the number 30 is hardcoded as the count in sound.py, so i removed the hardcoding in sound.py and similar files. 

after quick and dirty, non-extensive testing, these methods now respect the "count" argument properly. 