### PR TITLE
Add streaming download option to Video.bytes()

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.31.0,<3.0
 playwright>=1.36.0,<2.0
+httpx>=0.27.0,<1.0

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     download_url="https://github.com/davidteather/TikTok-Api/tarball/main",
     keywords=["tiktok", "python3", "api", "unofficial", "tiktok-api", "tiktok api"],
-    install_requires=["requests", "playwright"],
+    install_requires=["requests", "playwright", "httpx"],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",


### PR DESCRIPTION
### Add streaming
- Implements optional streaming functionality for video downloads
- Maintains existing non-streaming behavior as default
- Uses httpx for async streaming, keeps requests for synchronous downloads
- Adds minimal changes to existing codebase

Lets you handle larger videos by allowing concurrent processing or uploading of video chunks, while still keeping the current functionality for users who don’t need streaming.​

### Example Usage
```python
async def test_stream_bytes():
    async with TikTokApi() as api:
        await api.create_sessions(ms_tokens=[ms_token], num_sessions=1, sleep_after=3)
        video = api.video(url="https://www.tiktok.com/@davidteathercodes/video/7074717081563942186")
        
        await video.info()

        total_streamed_bytes = 0
        with open("streamed_BYTES.mp4", "wb") as f:
            async for chunk in await video.bytes(stream=True):
                f.write(chunk)
                total_streamed_bytes += len(chunk)
                print(f"Streamed chunk: {len(chunk)} bytes")
        print(f"Total streamed bytes: {total_streamed_bytes}")
```