### PR TITLE
fix: playwright timeout sessions with provide opt-out params

### DIFF
--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -143,6 +143,7 @@ class TikTokApi:
         sleep_after: int = 1,
         cookies: dict = None,
         suppress_resource_load_types: list[str] = None,
+        timeout: int = 300000,
     ):
         """Create a TikTokPlaywrightSession"""
         if ms_token is not None:
@@ -177,6 +178,9 @@ class TikTokApi:
                 if request.resource_type in suppress_resource_load_types
                 else route.continue_(),
             )
+        
+        # Set the navigation timeout
+        page.set_default_navigation_timeout(timeout)
 
         await page.goto(url)
 
@@ -213,7 +217,8 @@ class TikTokApi:
         cookies: list[dict] = None,
         suppress_resource_load_types: list[str] = None,
         browser: str = "chromium",
-        executable_path: str = None
+        executable_path: str = None,
+        timeout: int = 300000,
     ):
         """
         Create sessions for use within the TikTokApi class.
@@ -234,6 +239,7 @@ class TikTokApi:
             suppress_resource_load_types (list[str]): Types of resources to suppress playwright from loading, excluding more types will make playwright faster.. Types: document, stylesheet, image, media, font, script, textrack, xhr, fetch, eventsource, websocket, manifest, other.
             browser (str): specify either firefox or chromium, default is chromium
             executable_path (str): Path to the browser executable
+            timeout (int): The timeout in milliseconds for page navigation
 
         Example Usage:
             .. code-block:: python
@@ -271,6 +277,7 @@ class TikTokApi:
                     sleep_after=sleep_after,
                     cookies=random_choice(cookies),
                     suppress_resource_load_types=suppress_resource_load_types,
+                    timeout=timeout,
                 )
                 for _ in range(num_sessions)
             )


### PR DESCRIPTION
So, this PR is to provide opt-out solution for issues; #1185 and #994 

## **PROBLEMS**

when I try to figure out what is happening, most of the time the sessions is not long enough to handle the navigation process. This issue appear due to some problems such as; lack of resources when run the script, too much sessions to handle (ex: run alot of script once in a time), and another process block the session to finish.


## **SOLUTION**

By default, playwright timeout sessions is 3000ms == 30 seconds. For those problems above, this default timeouts is not enough. So with opt-out the timeout params via creating session , we can override default playwright timeout sessions before navigation started. 

## **IMPLEMENTATION**

This PR basically adding opt-out params when creating session. ex:

```python
await api.create_sessions(ms_tokens=[ms_token], num_sessions=1, sleep_after=3, timeout=60000)
````

this will let playwirght session started with 60secs timeout instead of 30s by default.