### PR TITLE
Fix Broken StealthConfig 

### DIFF
--- a/TikTokApi/stealth/stealth.py
+++ b/TikTokApi/stealth/stealth.py
@@ -76,12 +76,12 @@ class StealthConfig:
     iframe_content_window: bool = True
     media_codecs: bool = True
     navigator_hardware_concurrency: int = 4
-    navigator_languages: bool = True
+    navigator_languages: bool = False
     navigator_permissions: bool = True
     navigator_platform: bool = True
     navigator_plugins: bool = True
-    navigator_user_agent: bool = True
-    navigator_vendor: bool = True
+    navigator_user_agent: bool = False
+    navigator_vendor: bool = False
     outerdimensions: bool = True
     hairline: bool = True
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,7 +8,7 @@ ms_token = os.environ.get("ms_token", None)
 @pytest.mark.asyncio
 async def test_hashtag_videos():
     async with TikTokApi() as api:
-        await api.create_sessions(ms_tokens=[ms_token], num_sessions=1, sleep_after=3, browser=os.getenv("TIKTOK_BROWSER", "chromium"))
+        await api.create_sessions(headless=False, ms_tokens=[ms_token], num_sessions=1, sleep_after=3, browser=os.getenv("TIKTOK_BROWSER", "chromium"))
         tag_name = "funny"
         count = 0
         async for video in api.hashtag(name=tag_name).videos(count=1):


### PR DESCRIPTION
StealthConfig is broken by default on newer versions of playwright. There are three options that are set that make the browser open up to a blank page, causing an empty response from TikTok error:

- navigator_languages
- navigator_user_agent
- navigator_vendor

In this pull request, I set these parameters to False by default, fixing the blank screen when TikTok launches. This Pull request is essential to maintaining basic functionality on different versions of Playwright. Thank you for your consideration.