### PR TITLE
Fix asyncio.gather to wait for process to finish

### DIFF
--- a/TikTokApi/api/hashtag.py
+++ b/TikTokApi/api/hashtag.py
@@ -72,6 +72,7 @@ class Hashtag:
             url="https://www.tiktok.com/api/challenge/detail/",
             params=url_params,
             headers=kwargs.get("headers"),
+            session=kwargs.get("session"),
             session_index=kwargs.get("session_index"),
         )
 
@@ -119,6 +120,7 @@ class Hashtag:
                 url="https://www.tiktok.com/api/challenge/item_list/",
                 params=params,
                 headers=kwargs.get("headers"),
+                session=kwargs.get("session"),
                 session_index=kwargs.get("session_index"),
             )
 

--- a/TikTokApi/api/playlist.py
+++ b/TikTokApi/api/playlist.py
@@ -83,6 +83,7 @@ class Playlist:
             url="https://www.tiktok.com/api/mix/detail/",
             params=url_params,
             headers=kwargs.get("headers"),
+            session=kwargs.get("session"),
             session_index=kwargs.get("session_index"),
         )
 
@@ -124,6 +125,7 @@ class Playlist:
                 url="https://www.tiktok.com/api/mix/item_list/",
                 params=params,
                 headers=kwargs.get("headers"),
+                session=kwargs.get("session"),
                 session_index=kwargs.get("session_index"),
             )
 

--- a/TikTokApi/api/search.py
+++ b/TikTokApi/api/search.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
-from urllib.parse import urlencode
+
 from typing import TYPE_CHECKING, AsyncIterator
-from .user import User
+from urllib.parse import urlencode
+
 from ..exceptions import InvalidResponseException
+from .user import User
 
 if TYPE_CHECKING:
     from ..tiktok import TikTokApi
@@ -83,6 +85,7 @@ class Search:
                 params=params,
                 headers=kwargs.get("headers"),
                 session_index=kwargs.get("session_index"),
+                session=kwargs.get("session"),
             )
 
             if resp is None:

--- a/TikTokApi/api/sound.py
+++ b/TikTokApi/api/sound.py
@@ -74,6 +74,7 @@ class Sound:
             url="https://www.tiktok.com/api/music/detail/",
             params=url_params,
             headers=kwargs.get("headers"),
+            session=kwargs.get("session"),
             session_index=kwargs.get("session_index"),
         )
 
@@ -122,6 +123,7 @@ class Sound:
                 url="https://www.tiktok.com/api/music/item_list/",
                 params=params,
                 headers=kwargs.get("headers"),
+                session=kwargs.get("session"),
                 session_index=kwargs.get("session_index"),
             )
 

--- a/TikTokApi/api/trending.py
+++ b/TikTokApi/api/trending.py
@@ -44,6 +44,7 @@ class Trending:
                 url="https://www.tiktok.com/api/recommend/item_list/",
                 params=params,
                 headers=kwargs.get("headers"),
+                session=kwargs.get("session"),
                 session_index=kwargs.get("session_index"),
             )
 

--- a/TikTokApi/api/user.py
+++ b/TikTokApi/api/user.py
@@ -78,6 +78,7 @@ class User:
             url="https://www.tiktok.com/api/user/detail/",
             params=url_params,
             headers=kwargs.get("headers"),
+            session=kwargs.get("session"),
             session_index=kwargs.get("session_index"),
         )
 
@@ -121,6 +122,7 @@ class User:
                 url="https://www.tiktok.com/api/user/playlist",
                 params=params,
                 headers=kwargs.get("headers"),
+                session=kwargs.get("session"),
                 session_index=kwargs.get("session_index"),
             )
 
@@ -173,6 +175,7 @@ class User:
                 url="https://www.tiktok.com/api/post/item_list/",
                 params=params,
                 headers=kwargs.get("headers"),
+                session=kwargs.get("session"),
                 session_index=kwargs.get("session_index"),
             )
 
@@ -228,6 +231,7 @@ class User:
                 url="https://www.tiktok.com/api/favorite/item_list",
                 params=params,
                 headers=kwargs.get("headers"),
+                session=kwargs.get("session"),
                 session_index=kwargs.get("session_index"),
             )
 

--- a/TikTokApi/api/video.py
+++ b/TikTokApi/api/video.py
@@ -1,19 +1,22 @@
 from __future__ import annotations
-from ..helpers import extract_video_id_from_url, requests_cookie_to_playwright_cookie
-from typing import TYPE_CHECKING, ClassVar, AsyncIterator, Optional
-from datetime import datetime
-import requests
-from ..exceptions import InvalidResponseException
+
 import json
+from datetime import datetime
+from typing import TYPE_CHECKING, AsyncIterator, ClassVar, Optional, Union
+
 import httpx
-from typing import Union, AsyncIterator
+import requests
+
+from ..exceptions import InvalidResponseException
+from ..helpers import (extract_video_id_from_url,
+                       requests_cookie_to_playwright_cookie)
 
 if TYPE_CHECKING:
     from ..tiktok import TikTokApi
-    from .user import User
-    from .sound import Sound
-    from .hashtag import Hashtag
     from .comment import Comment
+    from .hashtag import Hashtag
+    from .sound import Sound
+    from .user import User
 
 
 class Video:
@@ -143,7 +146,7 @@ class Video:
             data = json.loads(r.text[start:end])
             default_scope = data.get("__DEFAULT_SCOPE__", {})
             video_detail = default_scope.get("webapp.video-detail", {})
-            if video_detail.get("statusCode", 0) != 0: # assume 0 if not present
+            if video_detail.get("statusCode", 0) != 0:  # assume 0 if not present
                 raise InvalidResponseException(
                     r.text, "TikTok returned an invalid response structure.", error_code=r.status_code
                 )
@@ -265,6 +268,7 @@ class Video:
                 url="https://www.tiktok.com/api/comment/list/",
                 params=params,
                 headers=kwargs.get("headers"),
+                session=kwargs.get("session"),
                 session_index=kwargs.get("session_index"),
             )
 
@@ -313,6 +317,7 @@ class Video:
                 url="https://www.tiktok.com/api/related/item_list/",
                 params=params,
                 headers=kwargs.get("headers"),
+                session=kwargs.get("session"),
                 session_index=kwargs.get("session_index"),
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["poetry-core>=1.8.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "TikTokApi"
+version = "0.0.0"
+description = "Local fork of TikTokApi with Playwright session injection fixes"
+authors = ["MegaEvolution Team <devnull@example.com>"]
+readme = "README.md"
+packages = [{ include = "TikTokApi" }]
+
+[tool.poetry.dependencies]
+python = ">=3.9,<4.0"
+playwright = ">=1.39,<2.0"


### PR DESCRIPTION
When using create session with multiple sessions, an asynchronous task is created in order to create these sessions. However, the default behavior is to immediately exit out if there is any error in creating the session. This behavior leaves behind dangling tasks not tracked by the caller, creating cases where more sessions are created than wanted when put into a while loop. This is more evident when using proxies and there are alot of cases where multiple __create_session can fail. As a result, I added a             return_exceptions=True so that it would wait until all tasks are considered done